### PR TITLE
Fix if whitespace triming

### DIFF
--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -13,7 +13,7 @@
             {{- ',' if not loop.last -}}
         {% endfor %}
     ) {% endif -%}
-    {% if external.using -%} using {{external.using}} {%- endif %}
+    {% if external.using %} using {{external.using}} {%- endif %}
     {% if options -%} options (
         {%- for key, value in options.items() -%}
             '{{ key }}' = '{{value}}' {{- ', \n' if not loop.last -}}


### PR DESCRIPTION
## Description & motivation
This change fixes an issue with the `create table using` syntax when no column is specified.

Before
*     create table schema.tablenusing net.snowflake.spark.snowflake
After
*      create table schema.table using net.snowflake.spark.snowflake

## Checklist
- [x] I have verified that these changes work locally

